### PR TITLE
Fix logs on Mac displaying incorrectly

### DIFF
--- a/Sources/OSLogViewer/OSLogViewer.Colors.swift
+++ b/Sources/OSLogViewer/OSLogViewer.Colors.swift
@@ -47,9 +47,9 @@ extension OSLogViewer {
 #elseif canImport(AppKit)
             Color(nsColor: .init(name: "debug", dynamicProvider: { traits in
                 if traits.name == .darkAqua || traits.name == .vibrantDark {
-                    return .init(red: 1, green: 1, blue: 1, alpha: 1)
-                } else {
                     return .init(red: 0.11, green: 0.11, blue: 0.12, alpha: 1)
+                } else {
+                    return .init(red: 1, green: 1, blue: 1, alpha: 1)
                 }
             }))
 #else


### PR DESCRIPTION
The colours on Mac were the wrong way round making the text unreadable. This PR fixes the issue.

<img width="500" alt="Screenshot 2025-02-14 at 5 11 06 pm" src="https://github.com/user-attachments/assets/fb12416c-6e1e-49e6-8073-373643abdd69" />

<img width="500" alt="Screenshot 2025-02-14 at 5 11 02 pm" src="https://github.com/user-attachments/assets/26845a73-846e-4bd8-ba4e-a10d87be2044" />